### PR TITLE
Compare filter checkbox values to state values in array instead of string to prevent false partial match

### DIFF
--- a/src/js/meom-filters.js
+++ b/src/js/meom-filters.js
@@ -189,22 +189,17 @@ const filters = () => {
             // Loop tax_query from config.
             const taxQueries = config.tax_query;
             for (const taxQuery of taxQueries) {
-                if (
-                    getStateFromUrl[taxQuery.urlKey] &&
-                    getStateFromUrl[taxQuery.urlKey].length > 0
-                ) {
+                const statesFromUrl = getStateFromUrl[taxQuery.urlKey];
+                if (statesFromUrl && statesFromUrl.length > 0) {
                     // Get all checkboxes based on name.
                     const allTaxCheckboxes = filtersForm.querySelectorAll(
                         `[name="${taxQuery.name}"]`
                     );
 
-                    // Loop them over and check them if URL query string includes the value.
+                    // Loop them over and check them if URL query parameter array includes the value.
+                    const statesFromUrlValues = statesFromUrl.split(',');
                     allTaxCheckboxes.forEach((checkbox) => {
-                        if (
-                            getStateFromUrl[`${taxQuery.urlKey}`].includes(
-                                checkbox.value
-                            )
-                        ) {
+                        if (statesFromUrlValues.includes(checkbox.value)) {
                             checkbox.checked = true;
                         }
                     });


### PR DESCRIPTION
If checkboxes had values "100cm and "alle 100cm" value "100cm" matched both of them when comparing full url string and resulted wrong list of selected values when refreshing page. Splitted url value string to an array to make compare work right.

Closes https://github.com/MEOM/meom-filters/issues/6